### PR TITLE
作品取得のページネーションを実装

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -69,7 +69,7 @@ const docTemplate = `{
         },
         "/works": {
             "get": {
-                "description": "Get all works",
+                "description": "Get all works with pagination",
                 "produces": [
                     "application/json"
                 ],
@@ -77,6 +77,20 @@ const docTemplate = `{
                     "works"
                 ],
                 "summary": "Get all works",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit per page (default: 20, max: 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -374,6 +388,15 @@ const docTemplate = `{
         "github_com_simesaba80_toybox-back_internal_interface_schema.WorkListResponse": {
             "type": "object",
             "properties": {
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total_count": {
+                    "type": "integer"
+                },
                 "works": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -63,7 +63,7 @@
         },
         "/works": {
             "get": {
-                "description": "Get all works",
+                "description": "Get all works with pagination",
                 "produces": [
                     "application/json"
                 ],
@@ -71,6 +71,20 @@
                     "works"
                 ],
                 "summary": "Get all works",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit per page (default: 20, max: 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -368,6 +382,15 @@
         "github_com_simesaba80_toybox-back_internal_interface_schema.WorkListResponse": {
             "type": "object",
             "properties": {
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total_count": {
+                    "type": "integer"
+                },
                 "works": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -130,6 +130,12 @@ definitions:
     type: object
   github_com_simesaba80_toybox-back_internal_interface_schema.WorkListResponse:
     properties:
+      limit:
+        type: integer
+      page:
+        type: integer
+      total_count:
+        type: integer
       works:
         items:
           $ref: '#/definitions/github_com_simesaba80_toybox-back_internal_interface_schema.GetWorkOutput'
@@ -178,7 +184,16 @@ paths:
       - users
   /works:
     get:
-      description: Get all works
+      description: Get all works with pagination
+      parameters:
+      - description: 'Limit per page (default: 20, max: 100)'
+        in: query
+        name: limit
+        type: integer
+      - description: 'Page number (default: 1)'
+        in: query
+        name: page
+        type: integer
       produces:
       - application/json
       responses:

--- a/internal/domain/repository/work.go
+++ b/internal/domain/repository/work.go
@@ -8,7 +8,7 @@ import (
 )
 
 type WorkRepository interface {
-	GetAll(ctx context.Context) ([]*entity.Work, error)
+	GetAll(ctx context.Context, limit, offset int) ([]*entity.Work, int, error)
 	GetByID(ctx context.Context, id uuid.UUID) (*entity.Work, error)
 	Create(ctx context.Context, work *entity.Work) (*entity.Work, error)
 }

--- a/internal/interface/controller/work.go
+++ b/internal/interface/controller/work.go
@@ -22,9 +22,11 @@ func NewWorkController(workUsecase *usecase.WorkUseCase) *WorkController {
 
 // GetAllWorks godoc
 // @Summary Get all works
-// @Description Get all works
+// @Description Get all works with pagination
 // @Tags works
 // @Produce json
+// @Param limit query int false "Limit per page (default: 20, max: 100)"
+// @Param page query int false "Page number (default: 1)"
 // @Success 200 {object} schema.WorkListResponse
 // @Router /works [get]
 func (wc *WorkController) GetAllWorks(c echo.Context) error {

--- a/internal/interface/schema/work.go
+++ b/internal/interface/schema/work.go
@@ -32,8 +32,16 @@ type CreateWorkOutput struct {
 	UpdatedAt   string `json:"updated_at"`
 }
 
+type GetWorksQuery struct {
+	Limit *int `query:"limit" validate:"omitempty,min=1,max=100"`
+	Page  *int `query:"page" validate:"omitempty,min=1"`
+}
+
 type WorkListResponse struct {
-	Works []GetWorkOutput `json:"works"`
+	Works      []GetWorkOutput `json:"works"`
+	TotalCount int             `json:"total_count"`
+	Page       int             `json:"page"`
+	Limit      int             `json:"limit"`
 }
 
 func ToWorkResponse(work *entity.Work) GetWorkOutput {


### PR DESCRIPTION
作品取得においてページネーションを実装しました。

pageとlimitをクエリパラメータとして渡すことで使えます。

pageは1以上の整数、limitは1以上100以下の整数を指定できます。
それぞれデフォルトでは1と20を渡します。

また、今回の実装に伴い一時的に作品を20件だけ返却するようにしていた箇所を削除しています。